### PR TITLE
Fixes for "Edit Pose Details" & UI Improvements

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -56,7 +56,7 @@ export default function PhotographyPoseGuide() {
     typeof window !== 'undefined' && window.innerWidth < 768 ? 2 : 3
   );
   const [showCategoryGridDropdown, setShowCategoryGridDropdown] = useState(false);
-  const [gridColumns, setGridColumns] = useState(2);
+  const [gridColumns, setGridColumns] = useState(3);
   const [showGridDropdown, setShowGridDropdown] = useState(false);
 
   // Modals
@@ -442,11 +442,12 @@ export default function PhotographyPoseGuide() {
           currentIndex={currentImageIndex}
           totalImages={category.images.length}
           categoryName={category.name}
-		  category={category}
+          category={category}
           onClose={() => setViewMode('grid')}
           onToggleFavorite={() => handleToggleFavorite(category.id, currentImageIndex)}
           onPrevious={() => setCurrentImageIndex(currentImageIndex - 1)}
           onNext={() => setCurrentImageIndex(currentImageIndex + 1)}
+          onUpdateImage={updateImage}
         />
       )}
 
@@ -500,6 +501,7 @@ export default function PhotographyPoseGuide() {
             onUpdateTags={(catId, imgIndex, tags) => updateImage(catId, imgIndex, { tags })}
             onUpdateNotes={(catId, imgIndex, notes) => updateImage(catId, imgIndex, { notes })}
             onUpdatePoseName={(catId, imgIndex, poseName) => updateImage(catId, imgIndex, { poseName })}
+            onUpdate={(catId, imgIndex, updates) => updateImage(catId, imgIndex, updates)}
             onForceSave={forceSave}
           />
         );


### PR DESCRIPTION
### Various Bug Fixes

- Corrects the "Edit Pose Details" page so that all fields will save properly.
- Corrects issue where typing in a Pose Name and then adding tags without saving first would cause the Pose Name to disappear.

### Pose Gallery UI Updates

- Tags in the footer when viewing an image can now be clicked to load a pop-up showing all tags.
- You can now tap the Name of the image at the top and change it on the page without going to "Edit Pose Details"